### PR TITLE
feat: variant without heading

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -11,21 +11,21 @@
 // List of projects/orgs using your project for the users page.
 const users = [
   {
-    caption: 'User1',
+    caption: "User1",
     // You will need to prepend the image path with your baseUrl
     // if it is not '/', like: '/test-site/img/image.jpg'.
-    image: '/img/undraw_open_source.svg',
-    infoLink: 'https://www.facebook.com',
+    image: "/img/undraw_open_source.svg",
+    infoLink: "https://www.facebook.com",
     pinned: true,
   },
 ];
 
 const siteConfig = {
-  title: 'Project Kamp Community', // Title for your website.
-  tagline: 'Building our offline community',
-  url: 'community.projectkamp.com', // Your website URL
+  title: "Project Kamp Community", // Title for your website.
+  tagline: "Building our offline community",
+  url: "community.projectkamp.com", // Your website URL
   baseUrl: "/",
-  onPageNav: 'separate',
+  onPageNav: "separate",
   // remove /docs/ prefix
   docsUrl: "academy",
   // For github.io type URLs, you would set the url and baseUrl like:
@@ -33,29 +33,29 @@ const siteConfig = {
   //   baseUrl: '/test-site/',
 
   // Used for publishing and more
-  projectName: 'project-kamp-academy',
-  organizationName: 'davehakkens',
+  projectName: "project-kamp-academy",
+  organizationName: "davehakkens",
   // For top-level user or org sites, the organization is still the same.
   // e.g., for the https://JoelMarcey.github.io site, it would be set like...
   //   organizationName: 'JoelMarcey'
 
   // For no header links in the top nav bar -> headerLinks: [],
   headerLinks: [
-    { href: 'https://projectkamp.com', label: 'back to main' },
+    // { href: 'https://projectkamp.com', label: 'back to main' },
   ],
 
   // If you have users set above, you add it here:
   users,
 
   /* path to images for header/footer */
-  headerIcon: 'img/logo.png',
-  footerIcon: 'img/favicon.ico',
-  favicon: 'img/favicon.ico',
+  headerIcon: false,
+  footerIcon: "img/favicon.ico",
+  favicon: "img/favicon.ico",
 
   /* Colors for website */
   colors: {
-    primaryColor: '#8ab57f',
-    secondaryColor: '#416e39',
+    primaryColor: "#8ab57f",
+    secondaryColor: "#416e39",
   },
   editUrl: "https://github.com/ONEARMY/project-kamp-academy/blob/master/docs/",
 
@@ -73,8 +73,17 @@ const siteConfig = {
   },
   */
   fonts: {
-    bodyFont: ["-apple-system", "BlinkMacSystemFont", "Segoe UI", "Helvetica", "Arial",
-    "sans-serif", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"]
+    bodyFont: [
+      "-apple-system",
+      "BlinkMacSystemFont",
+      "Segoe UI",
+      "Helvetica",
+      "Arial",
+      "sans-serif",
+      "Apple Color Emoji",
+      "Segoe UI Emoji",
+      "Segoe UI Symbol",
+    ],
   },
 
   // This copyright info is used in /core/Footer.js and blog RSS/Atom feeds.
@@ -82,24 +91,24 @@ const siteConfig = {
 
   highlight: {
     // Highlight.js theme to use for syntax highlighting in code blocks.
-    theme: 'default',
+    theme: "default",
   },
 
   // Add custom scripts here that would be placed in <script> tags.
   scripts: [
-  "https://buttons.github.io/buttons.js",
-  "/js/custom.js",
-  "https://cdnjs.cloudflare.com/ajax/libs/tiny-slider/2.9.2/min/tiny-slider.js"
-],
+    "https://buttons.github.io/buttons.js",
+    "/js/custom.js",
+    "https://cdnjs.cloudflare.com/ajax/libs/tiny-slider/2.9.2/min/tiny-slider.js",
+  ],
 
   // On page navigation for the current documentation page.
-  onPageNav: 'separate',
+  onPageNav: "separate",
   // No .html extensions for paths.
   cleanUrl: true,
 
   // Open Graph and Twitter card images.
-  ogImage: 'img/undraw_online.svg',
-  twitterImage: 'img/undraw_tweetstorm.svg',
+  ogImage: "img/undraw_online.svg",
+  twitterImage: "img/undraw_tweetstorm.svg",
 
   // For sites with a sizable amount of content, set collapsible to true.
   // Expand/collapse the links and subcategories under categories.

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -6,14 +6,12 @@ body {
   font-family: $bodyFont;
 }
 
-
 .headerTitleWithLogo {
-    display: none !important;
+  display: none !important;
 }
 
-
-.mainContainer{
-padding: 60px 0;
+.mainContainer {
+  padding: 60px 0;
 }
 
 .button {
@@ -43,44 +41,44 @@ padding: 60px 0;
 
 #tocToggler {
   display: none;
-
 }
 
-.fixedHeaderContainer a
-{display:inline-block;}
+.fixedHeaderContainer a {
+  display: inline-block;
+}
 
 .navGroups ul {
-    margin-bottom: 0px;
+  margin-bottom: 0px;
 }
 
 .toc .toggleNav .navGroup .navGroupCategoryTitle,
-.toc .toggleNav .navGroup{
-  margin-bottom:0px;
+.toc .toggleNav .navGroup {
+  margin-bottom: 0px;
 }
 .navGroupCategoryTitle.collapsible,
-.toc .toggleNav ul li a{
-  padding: 8px 10px ;
+.toc .toggleNav ul li a {
+  padding: 8px 10px;
   font-size: 0.9rem;
   width: 100%;
 }
 .navListItem:hover,
 .navListItem:active,
 .navGroupCategoryTitle.collapsible:hover,
-.navGroupCategoryTitle.collapsible:active  {
-  background-color:rgba(0,0,0,.05);
+.navGroupCategoryTitle.collapsible:active {
+  background-color: rgba(0, 0, 0, 0.05);
 }
 
 .navGroupCategoryTitle.collapsible,
 .navListItem {
-    border-radius: .25rem;
-    color: #606770;
-    color: var(--ifm-menu-color);
-    cursor: pointer;
-    display: flex;
-    line-height: 20px;
-    justify-content: space-between;
-    text-decoration: none;
-    margin: 0;
+  border-radius: 0.25rem;
+  color: #606770;
+  color: var(--ifm-menu-color);
+  cursor: pointer;
+  display: flex;
+  line-height: 20px;
+  justify-content: space-between;
+  text-decoration: none;
+  margin: 0;
 }
 
 article .videocontainer {
@@ -109,8 +107,6 @@ a {
   color: rgb(131, 206, 235);
   color: var(--links, var(--highlight, $primaryColor));
 }
-
-
 
 a:hover {
   color: rgb(131, 206, 235);
@@ -150,26 +146,27 @@ article div span h1:first-child {
 h1,
 h2,
 h3 {
-  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
+  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial,
+    sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
 }
-
 
 .videoChapters {
   display: flex;
 }
 
-.onPageNav{
+.onPageNav {
   flex: inherit;
-  display:none!important;
+  display: none !important;
 }
 
 .videoChaptersSidebar {
   display: none;
 }
 
-
+.docsNavContainer,
 .navPusher {
-  padding-top: 50px;
+  padding-top: 0 !important;
+  min-height: 100vh !important;
 }
 
 /* Edit page button */
@@ -179,7 +176,6 @@ a.edit-page-link {
   color: black;
   font-size: 14px;
 }
-
 
 table th,
 table td {
@@ -212,31 +208,27 @@ hr {
 
 /* Desktop and up */
 @media only screen and (min-width: 1024px) {
-
-
-.separateOnPageNav .wrapper, .separateOnPageNav .headerWrapper.wrapper{
-  max-width: inherit;
-}
-
-
+  .separateOnPageNav .wrapper,
+  .separateOnPageNav .headerWrapper.wrapper {
+    max-width: inherit;
+  }
 
   .wrapper {
     padding: 0px 50px;
   }
 
-.separateOnPageNav .wrapper{
-  max-width: inherit;
-}
-.separateOnPageNav .docsNavContainer{
-  flex: 0 0 300px;
-  padding: 0px 15px;
-}
+  .separateOnPageNav .wrapper {
+    max-width: inherit;
+  }
+  .separateOnPageNav .docsNavContainer {
+    flex: 0 0 300px;
+    padding: 0px 15px;
+  }
 
   .docsNavContainer {
     top: 0px;
     border-right: 1px solid black;
     box-sizing: border-box;
-
   }
 
   .separateOnPageNav.sideNavVisible .navPusher .mainContainer {
@@ -286,4 +278,8 @@ hr {
   text-align: center;
   opacity: 0;
   text-transform: uppercase;
+}
+
+.fixedHeaderContainer {
+  display: none;
 }


### PR DESCRIPTION
When the new Platform powered variant of the community.projectkamp.com/ site is launched we will
serve the academy within an iframe. Once that change has
been made we will now longer need the header block on this site.

![Demo of the site without the heading component](https://user-images.githubusercontent.com/472589/142737229-a6777a3f-0bd8-4eb5-b6b7-f22d6b8a2a63.jpg)

Note: My editor has automatically applied Prettier formatting to the modified files. Let me know if you would rather that was removed. 