### PR TITLE
fix: remove academy from URL

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -26,8 +26,9 @@ const siteConfig = {
   url: "community.projectkamp.com", // Your website URL
   baseUrl: "/",
   onPageNav: "separate",
+
   // remove /docs/ prefix
-  docsUrl: "academy",
+  docsUrl: "",
   // For github.io type URLs, you would set the url and baseUrl like:
   //   url: 'https://facebook.github.io',
   //   baseUrl: '/test-site/',

--- a/website/static/index.html
+++ b/website/static/index.html
@@ -5,12 +5,12 @@
     <!-- Make landing page academy -->
     <meta http-equiv="refresh" content="0; url=intro.html" />
     <script type="text/javascript">
-      window.location.href = "academy/start/intro.html";
+      window.location.href = "start/intro.html";
     </script>
-    <title>Your Site Title Here</title>
+    <title>Project Kamp Community</title>
   </head>
   <body>
     If you are not redirected automatically, follow this
-    <a href="intro.html">link</a>.
+    <a href="start/intro.html">link</a>.
   </body>
 </html>


### PR DESCRIPTION
We do not need to include `/academy` in the URL structure for this property. This site will eventually appear within an iframe on `https://community.projectkamp.com/academy/` however that is an implementation detail that this code does not need to be aware of. 