### PR TITLE
fix: check for linkElement on external links

### DIFF
--- a/website/static/js/custom.js
+++ b/website/static/js/custom.js
@@ -196,8 +196,11 @@ function passLinkClicksToParent() {
     if (!node.href.includes(location.host)) {
       node.addEventListener("click", ev => {
         ev.preventDefault();
-        const href = ev.target.href;
-        parent.postMessage({ linkClick: href }, "*");
+        const linkElement = ev.target.closest('a');
+        if(linkElement) {
+          const href = ev.target.href;
+          parent.postMessage({ linkClick: href }, "*");
+        }
       });
     }
   });


### PR DESCRIPTION
Fixes: https://github.com/ONEARMY/project-kamp-academy/issues/35

External links, when wrapped around images, don't work. External links that are just text work. This is because the check for `ev.target.href` doesn't have an `href` because the element in question is the `img`. Any element wrapped in an a tag should still work. See issue for screenshots.

Added check for closest `a` tag.